### PR TITLE
gym version fixed to 0.25

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.8.0
 moviepy>=1.0.0
 scipy
-gym
+gym==0.25
 pygame


### PR DESCRIPTION
gym's calling format has been changed since the original version. This patch ensures that a suitable (older) version of gym is installed. Version newer than 0.25 do not seem to work. 

The only change made is "gym" --> "gym==0.25" in requirements.txt